### PR TITLE
Xgerman/local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .azure
+.venv

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -6,8 +6,15 @@ Requirements:
 
 - Python (3.8+)
 
+**Recommended:** Install a Python [venv](https://docs.python.org/3/library/venv.html)
+
 ```bash
-$ pip install -r requirements.txt
+$ python3 -m venv .venv
+$ . .venv/bin/activate
+```
+
+```bash
+$ pip install -r src/api/requirements.txt
 ```
 
 Or
@@ -15,6 +22,29 @@ Or
 ```bash
 $ poetry install
 ```
+
+## Running with DocumentDB on local host
+
+Start the DoucmentDB Docker image:
+
+```bash
+$ docker run -dt -p 10260:10260 documentdboss.azurecr.io/private-preview-manifest:0.0.
+```
+**Note:** Check TBD for more configuration parameters
+
+Then set the `AZURE_COSMOS_CONNECTION_STRING` to the following value:
+```bash
+export AZURE_COSMOS_CONNECTION_STRING="mongodb://default_user:Admin100@localhost:10260/?directConnection=true&serverSelectionTimeoutMS=2000&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&appName=mongosh+2.5.0"
+```
+
+You might need to adjust the username `default_user` or the password `Admin100` or the port `10260` if you customized this
+when starting the docker container.
+
+There is also a docker-compose.file you cna use to run both containers. To do so:
+```bash
+$ docker-compose up
+```
+You then can access the todo application like noted in "Running in Docker"
 
 ## Running
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -28,7 +28,7 @@ $ poetry install
 Start the DoucmentDB Docker image:
 
 ```bash
-$ docker run -dt -p 10260:10260 documentdboss.azurecr.io/private-preview-manifest:0.0.
+$ docker run -dt -p 10260:10260 ghcr.io/microsoft/documentdb/documentdb-local:latest
 ```
 **Note:** Check TBD for more configuration parameters
 

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  api:
+    build:
+      context: ./src/api
+      dockerfile: Dockerfile
+    ports:
+      - "8080:3100"
+    environment:
+      - AZURE_COSMOS_CONNECTION_STRING=mongodb://default_user:Admin100@documentdb:10260/?directConnection=true&serverSelectionTimeoutMS=2000&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&appName=mongosh+2.5.0
+      - AZURE_COSMOS_DATABASE_NAME=todo_db
+    depends_on:
+      - documentdb
+    networks:
+      - todo-network
+
+  documentdb:
+    image: documentdboss.azurecr.io/private-preview:0.0.1
+    ports:
+      - "10260:10260"
+    networks:
+      - todo-network
+    volumes:
+      - documentdb-data:/data/db
+
+networks:
+  todo-network:
+    driver: bridge
+
+volumes:
+  documentdb-data:

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -1,14 +1,15 @@
 version: '3.8'
 
+# to have custom username/passwd run `DOCUMENT_DB_USERNAME=my_custom_user DOCUMENT_DB_PASSWORD=my_secure_password docker-compose up`
 services:
   api:
     build:
-      context: ./src/api
+      context: .
       dockerfile: Dockerfile
     ports:
       - "8080:3100"
     environment:
-      - AZURE_COSMOS_CONNECTION_STRING=mongodb://default_user:Admin100@documentdb:10260/?directConnection=true&serverSelectionTimeoutMS=2000&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&appName=mongosh+2.5.0
+      - AZURE_COSMOS_CONNECTION_STRING=mongodb://${DOCUMENT_DB_USERNAME:-todo_admin}:${DOCUMENT_DB_PASSWORD:-Admin100}@documentdb:10260/?directConnection=true&serverSelectionTimeoutMS=2000&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&appName=todo-app
       - AZURE_COSMOS_DATABASE_NAME=todo_db
     depends_on:
       - documentdb
@@ -16,9 +17,12 @@ services:
       - todo-network
 
   documentdb:
-    image: documentdboss.azurecr.io/private-preview:0.0.1
+    image: documentdboss.azurecr.io/private-preview:0.0.2
     ports:
       - "10260:10260"
+    environment:
+      - USERNAME=${DOCUMENT_DB_USERNAME:-todo_admin}
+      - PASSWORD=${DOCUMENT_DB_PASSWORD:-Admin100}
     networks:
       - todo-network
     volumes:

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - todo-network
 
   documentdb:
-    image: documentdboss.azurecr.io/private-preview:0.0.2
+    image: ghcr.io/microsoft/documentdb/documentdb-local:latest
     ports:
       - "10260:10260"
     environment:


### PR DESCRIPTION
Adds docker-compose and additional information to the readme to run the demo locally with the documentdb-local image